### PR TITLE
MUTATIONOFJB: Fix multiple RANDOM commands in one script.

### DIFF
--- a/engines/mutationofjb/commands/randomcommand.cpp
+++ b/engines/mutationofjb/commands/randomcommand.cpp
@@ -74,8 +74,13 @@ bool RandomBlockStartParser::parse(const Common::String &line, ScriptParseContex
 }
 
 void RandomBlockStartParser::transition(ScriptParseContext &parseCtx, Command *, Command *newCommand, CommandParser *) {
-	if (newCommand && parseCtx._pendingRandomCommand) {
-		parseCtx._pendingRandomCommand->_choices.push_back(newCommand);
+	RandomCommand *randomCommand = parseCtx._pendingRandomCommand;
+	if (newCommand && randomCommand) {
+		randomCommand->_choices.push_back(newCommand);
+
+		if (randomCommand->_choices.size() == randomCommand->_numChoices) {
+			parseCtx._pendingRandomCommand = nullptr;
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes the first RANDOM command eating all further ones. AFAIK, no original script uses multiple RANDOM commands but the original engine handles it correctly.