### PR TITLE
MUTATIONOFJB: Implement word wrapping for subtitles.

### DIFF
--- a/engines/mutationofjb/font.h
+++ b/engines/mutationofjb/font.h
@@ -37,17 +37,20 @@ class Font {
 public:
 	Font(const Common::String &fileName, int horizSpacing, int vertSpacing);
 	virtual ~Font() {}
-	void drawString(const Common::String &str, uint8 baseColor, int16 x, int16 y, Graphics::ManagedSurface &surf);
+	int getLineHeight() const;
+	int16 getWidth(const Common::String &text) const;
+	void drawString(const Common::String &str, uint8 baseColor, int16 x, int16 y, Graphics::ManagedSurface &surf) const;
+	void wordWrap(const Common::String &str, int16 maxLineWidth, Common::Array<Common::String> &lines) const;
 
 protected:
-	virtual uint8 transformColor(uint8 baseColor, uint8 glyphColor);
+	virtual uint8 transformColor(uint8 baseColor, uint8 glyphColor) const;
 
 private:
-	void drawGlyph(uint8 glyph, uint8 baseColor, int16 &x, int16 &y, Graphics::ManagedSurface &surf);
+	void drawGlyph(uint8 glyph, uint8 baseColor, int16 &x, int16 &y, Graphics::ManagedSurface &surf) const;
 	bool load(const Common::String &fileName);
 
 	int _horizSpacing;
-	int _vertSpacing;
+	int _lineHeight;
 	typedef Common::HashMap<uint8, Graphics::ManagedSurface> GlyphMap;
 	GlyphMap _glyphs;
 };
@@ -62,7 +65,7 @@ public:
 	SpeechFont();
 
 protected:
-	virtual uint8 transformColor(uint8 baseColor, uint8 glyphColor) override;
+	virtual uint8 transformColor(uint8 baseColor, uint8 glyphColor) const override;
 };
 
 }

--- a/engines/mutationofjb/tasks/saytask.h
+++ b/engines/mutationofjb/tasks/saytask.h
@@ -24,6 +24,7 @@
 
 #include "mutationofjb/timer.h"
 
+#include "common/rect.h"
 #include "common/str.h"
 
 namespace MutationOfJB {
@@ -36,9 +37,12 @@ public:
 	virtual void update() override;
 
 private:
+	void drawSubtitle(const Common::String &text, int16 talkX, int16 talkY, uint8 color);
+
 	Common::String _toSay;
 	uint8 _color;
 	Timer _timer;
+	Common::Rect _boundingBox;
 };
 
 }


### PR DESCRIPTION
For now the subtitles are drawn on the top of the screen but we should respect PTALK (where to show subtitles in general) and LTALK (where to show the responder's subtitles in an interactive conversation) commands in the future. I also compute the bounding box of the text to make it easier to address `TODO: Only redraw the area occupied by the text.`.