### PR TITLE
MUTATIONOFJB: Subclass Graphics::Font.

### DIFF
--- a/engines/mutationofjb/font.h
+++ b/engines/mutationofjb/font.h
@@ -25,7 +25,9 @@
 
 #include "common/scummsys.h"
 #include "common/hashmap.h"
+#include "graphics/font.h"
 #include "graphics/managed_surface.h"
+#include "graphics/surface.h"
 
 namespace Common {
 class String;
@@ -33,24 +35,26 @@ class String;
 
 namespace MutationOfJB {
 
-class Font {
+class Font : public Graphics::Font {
+	friend class FontBlitOperation;
 public:
-	Font(const Common::String &fileName, int horizSpacing, int vertSpacing);
-	virtual ~Font() {}
-	int getLineHeight() const;
-	int16 getWidth(const Common::String &text) const;
-	void drawString(const Common::String &str, uint8 baseColor, int16 x, int16 y, Graphics::ManagedSurface &surf) const;
-	void wordWrap(const Common::String &str, int16 maxLineWidth, Common::Array<Common::String> &lines) const;
+	Font(const Common::String &fileName, int horizSpacing, int lineHeight);
+
+	virtual int getFontHeight() const override;
+	virtual int getMaxCharWidth() const override;
+	virtual int getCharWidth(uint32 chr) const override;
+	virtual int getKerningOffset(uint32 left, uint32 right) const override;
+	virtual void drawChar(Graphics::Surface *dst, uint32 chr, int x, int y, uint32 color) const override;
 
 protected:
 	virtual uint8 transformColor(uint8 baseColor, uint8 glyphColor) const;
 
 private:
-	void drawGlyph(uint8 glyph, uint8 baseColor, int16 &x, int16 &y, Graphics::ManagedSurface &surf) const;
 	bool load(const Common::String &fileName);
 
 	int _horizSpacing;
 	int _lineHeight;
+	int _maxCharWidth;
 	typedef Common::HashMap<uint8, Graphics::ManagedSurface> GlyphMap;
 	GlyphMap _glyphs;
 };

--- a/engines/mutationofjb/widgets/conversationwidget.cpp
+++ b/engines/mutationofjb/widgets/conversationwidget.cpp
@@ -69,7 +69,7 @@ void ConversationWidget::_draw(Graphics::ManagedSurface &surface) {
 		}
 
 		// TODO: Active line should be WHITE.
-		_gui.getGame().getAssets().getSystemFont().drawString(str, LIGHTGRAY, CONVERSATION_LINES_X, CONVERSATION_LINES_Y + i * CONVERSATION_LINE_HEIGHT, surface);
+		_gui.getGame().getAssets().getSystemFont().drawString(&surface, str, CONVERSATION_LINES_X, CONVERSATION_LINES_Y + i * CONVERSATION_LINE_HEIGHT, _area.width(), LIGHTGRAY);
 	}
 }
 


### PR DESCRIPTION
Work in progress. This is an attempt to address sev's comment about reusing ScummVM's `wordWrapText` function: https://github.com/LubomirR/scummvm/commit/907660e58b217879a1339d8a411d8d0c2082c148#r29794381.

Unfortunately, the switch to Graphics::Font breaks word wrapping in the following instance (the third line breaks differently):

This PR:
![image](https://user-images.githubusercontent.com/7346770/43093953-e9371ad6-8eb1-11e8-9086-adbe55dfb84e.png)

Vanilla (and our engine before this PR):
![image](https://user-images.githubusercontent.com/7346770/43093833-7de91202-8eb1-11e8-8468-1d0201dba78b.png)

For some reason, the third line exceeds `maxWidth` given to `wordWrapText`. It looks like there may be a bug in `wordWrapText` with respect to how we implement `getKerningOffset`. I'm not sure yet but I suspect this code to be the culprit: https://github.com/scummvm/scummvm/blob/7b0402fbb0dc9fa5759b7f059ada915d72677e4d/graphics/font.cpp#L213